### PR TITLE
Updated example local-config.yaml for newer Loki versions.

### DIFF
--- a/configs/loki/local-config.yaml
+++ b/configs/loki/local-config.yaml
@@ -3,55 +3,24 @@ auth_enabled: false
 server:
   http_listen_port: 3100
 
-ingester:
-  wal:
-    dir: /loki/wal
-  lifecycler:
-    address: 127.0.0.1
-    ring:
-      kvstore:
-        store: inmemory
-      replication_factor: 1
-    final_sleep: 0s
-  chunk_idle_period: 5m
-  chunk_retain_period: 30s
-  max_transfer_retries: 0
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
 
 schema_config:
   configs:
-    - from: 2018-04-15
-      store: boltdb
-      object_store: filesystem
-      schema: v11
-      index:
-        prefix: index_
-        period: 168h
+  - from: 2020-05-15
+    store: tsdb
+    object_store: filesystem
+    schema: v13
+    index:
+      prefix: index_
+      period: 24h
 
 storage_config:
-  boltdb:
-    directory: /loki/index
-
   filesystem:
     directory: /loki/chunks
-
-limits_config:
-  enforce_metric_name: false
-  reject_old_samples: true
-  reject_old_samples_max_age: 168h
-
-chunk_store_config:
-  max_look_back_period: 0s
-
-table_manager:
-  chunk_tables_provisioning:
-    inactive_read_throughput: 0
-    inactive_write_throughput: 0
-    provisioned_read_throughput: 0
-    provisioned_write_throughput: 0
-  index_tables_provisioning:
-    inactive_read_throughput: 0
-    inactive_write_throughput: 0
-    provisioned_read_throughput: 0
-    provisioned_write_throughput: 0
-  retention_deletes_enabled: true
-  retention_period: 672h


### PR DESCRIPTION
The current example local-config.yaml causes the latest version of Loki to crash.

I based this new config on examples found here: https://grafana.com/docs/loki/latest/configure/examples/configuration-examples/#1-local-configuration-exampleyaml

Feel free to suggest any changes.